### PR TITLE
Require Alloy and Backbone.js

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -192,7 +192,7 @@ function Sync(model, method, opts) {
 };
 
 //we need underscore
-var _ = require("alloy/underscore")._;
+var Alloy = require("alloy"), Backbone = Alloy.Backbone, _ = Alloy._, A$ = Alloy.A;
 
 module.exports.sync = Sync;
 


### PR DESCRIPTION
Android device build have Alloy.Backbone undefined error.

tiTokyo conference application using this library.
https://github.com/k0sukey/tiTokyo

Thanks :)
