### PR TITLE
If params.url comes from model.url() errors occur

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -162,7 +162,7 @@ function Sync(method, model, opts) {
 
 	// We need to ensure that we have a base url.
 	if (!params.url) {
-		params.url = (model.config.URL || model.url());
+		params.url = model.config.URL;
 		if (!params.url) {
 			Ti.API.error("[REST API] ERROR: NO BASE URL");
 			return;
@@ -228,7 +228,7 @@ function Sync(method, model, opts) {
 			break;
 
 		case 'read':
-			if (model.config.URL != null && model[model.idAttribute]) {
+			if (model[model.idAttribute]) {
 				params.url = params.url + '/' + model[model.idAttribute];
 			}
 
@@ -281,13 +281,11 @@ function Sync(method, model, opts) {
 			}
 			
 			// setup the url & data
-			if(model.config.URL != null) {
-				if (_.indexOf(params.url, "?") == -1) {
-					params.url = params.url + '/' + model[model.idAttribute];
-				} else {
-					var str = params.url.split("?");
-					params.url = str[0] + '/' + model[model.idAttribute] + "?" + str[1];
-				}
+			if (_.indexOf(params.url, "?") == -1) {
+				params.url = params.url + '/' + model[model.idAttribute];
+			} else {
+				var str = params.url.split("?");
+				params.url = str[0] + '/' + model[model.idAttribute] + "?" + str[1];
 			}
 
 			if (params.urlparams) {
@@ -318,9 +316,7 @@ function Sync(method, model, opts) {
 				return;
 			}
 			
-			if(model.config.URL != null) {
-				params.url = params.url + '/' + model[model.idAttribute];
-			}
+			params.url = params.url + '/' + model[model.idAttribute];
 
 			logger(DEBUG, "delete options", params);
 

--- a/restapi.js
+++ b/restapi.js
@@ -228,7 +228,7 @@ function Sync(method, model, opts) {
 			break;
 
 		case 'read':
-			if (model[model.idAttribute]) {
+			if (model.config.URL != null && model[model.idAttribute]) {
 				params.url = params.url + '/' + model[model.idAttribute];
 			}
 
@@ -279,13 +279,15 @@ function Sync(method, model, opts) {
 				Ti.API.error("[REST API] ERROR: MISSING MODEL ID");
 				return;
 			}
-
+			
 			// setup the url & data
-			if (_.indexOf(params.url, "?") == -1) {
-				params.url = params.url + '/' + model[model.idAttribute];
-			} else {
-				var str = params.url.split("?");
-				params.url = str[0] + '/' + model[model.idAttribute] + "?" + str[1];
+			if(model.config.URL != null) {
+				if (_.indexOf(params.url, "?") == -1) {
+					params.url = params.url + '/' + model[model.idAttribute];
+				} else {
+					var str = params.url.split("?");
+					params.url = str[0] + '/' + model[model.idAttribute] + "?" + str[1];
+				}
 			}
 
 			if (params.urlparams) {
@@ -315,7 +317,10 @@ function Sync(method, model, opts) {
 				Ti.API.error("[REST API] ERROR: MISSING MODEL ID");
 				return;
 			}
-			params.url = params.url + '/' + model[model.idAttribute];
+			
+			if(model.config.URL != null) {
+				params.url = params.url + '/' + model[model.idAttribute];
+			}
 
 			logger(DEBUG, "delete options", params);
 


### PR DESCRIPTION
(hello and great adapter!)

In my usage of this I have setup nested models/collections. 
For some of these, the model.config.URL cannot be used and is not there.
(For instance 'http://myapi.com/v1/users/20/contacts' )

But my models do produce the correct url with the model.url() call. 

The problem is without the changes I've proposed here my urls are as follows...
create -> http://myapi.com/v1/users/20/contacts (correct)
read -> http://myapi.com/v1/users/20/contacts/30/30 (incorrect)
update -> http://myapi.com/v1/users/20/contacts/30/30 (incorrect)
delete -> http://myapi.com/v1/users/20/contacts/30/30 (incorrect)

This pull request fixes the issue for me. I don't know if this is the best way to fix the problem, but I used this pull request to share the issue.
