### PR TITLE
More elegant solution to params.url and model.url() issue

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -162,7 +162,12 @@ function Sync(method, model, opts) {
 
 	// We need to ensure that we have a base url.
 	if (!params.url) {
-		params.url = (model.config.URL || model.url());
+		if(model.config.URL) { 
+		    model.urlRoot = model.config.URL;
+		}
+		
+		params.url = model.url();
+		
 		if (!params.url) {
 			Ti.API.error("[REST API] ERROR: NO BASE URL");
 			return;
@@ -228,10 +233,6 @@ function Sync(method, model, opts) {
 			break;
 
 		case 'read':
-			if (model[model.idAttribute]) {
-				params.url = params.url + '/' + model[model.idAttribute];
-			}
-
 			if (params.search) {
 				// search mode
 				params.url = params.url + "/search/" + Ti.Network.encodeURIComponent(params.search);
@@ -280,14 +281,6 @@ function Sync(method, model, opts) {
 				return;
 			}
 
-			// setup the url & data
-			if (_.indexOf(params.url, "?") == -1) {
-				params.url = params.url + '/' + model[model.idAttribute];
-			} else {
-				var str = params.url.split("?");
-				params.url = str[0] + '/' + model[model.idAttribute] + "?" + str[1];
-			}
-
 			if (params.urlparams) {
 				params.url = encodeData(params.urlparams, params.url);
 			}
@@ -315,7 +308,6 @@ function Sync(method, model, opts) {
 				Ti.API.error("[REST API] ERROR: MISSING MODEL ID");
 				return;
 			}
-			params.url = params.url + '/' + model[model.idAttribute];
 
 			logger(DEBUG, "delete options", params);
 


### PR DESCRIPTION
This solution also fixes my issue mentioned in the previous pull request.
https://github.com/viezel/napp.alloy.adapter.restapi/pull/36
