### PR TITLE
delete was handling arguments incorrectly

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -320,7 +320,13 @@ function Sync(method, model, opts) {
 				Ti.API.error("[REST API] ERROR: MISSING MODEL ID");
 				return;
 			}
-			params.url = params.url + '/' + model[model.idAttribute];
+			//params.url = params.url + '/' + model[model.idAttribute];
+			if (_.indexOf(params.url, "?") == -1) {
+							params.url = params.url + '/' + model.id;
+						} else {
+							var str = params.url.split("?");
+							params.url = str[0] + '/' + model.id + "?" + str[1];
+						}
 
 			logger(DEBUG, "delete options", params);
 


### PR DESCRIPTION
First, Thank you very much for creating this library. I make sure to show it to everyone who takes the TCD/TCE.

There is an inconsistency in how the delete verb is handling URLs.
It tries to append the model.id to the end of a URL string rather than splitting on ?

This humble patch fixes this issue.

Thanks again for the awesome adapter.
