### PR TITLE
Allow for more flexibility when working with get requests

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -242,6 +242,12 @@ function Sync(method, model, opts) {
 				params.url = encodeData(params.urlparams, params.url);
 			}
 
+			if ( ! params.urlparams && params.data) {
+                // If we have set optional parameters on the request we should use it
+                // when params.urlparams fails/is empty.
+                params.url = encodeData(params.data, params.url);
+            }
+
 			if (eTagEnabled) {
 				params.eTagEnabled = true;
 			}


### PR DESCRIPTION
If the api allows for more parameters through _GET then we should be
able to use them.

e.x: collection.fetch({data:{limit:15, language:’en’}});
