### PR TITLE
set Content-Type to application/json when method is 'create' or 'update'...

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -201,7 +201,9 @@ function Sync(method, model, opts) {
 	}
 
 	//json data transfers
-	params.headers['Content-Type'] = 'application/json';
+	if (!params.data && model && (method == 'create' || method == 'update')) {
+    	params.headers['Content-Type'] = 'application/json';
+    }
 
 	logger(DEBUG, "REST METHOD", method);
 


### PR DESCRIPTION
When read(GET) or delete(DELTE), `application/json` doesn't required. is it?

Check below code which is a backbone.js (v0.9.2) sync.
```javascript
if (!options.data && model && (method == 'create' || method == 'update')) {
      params.contentType = 'application/json';
      params.data = JSON.stringify(model.toJSON());
    }
```