### PR TITLE
Make sure that params.urlparams is not undefined before extending it

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -175,6 +175,7 @@ function Sync(method, model, opts) {
 
 	// Extend the provided url params with those from the model config
 	if (_.isObject(params.urlparams) || model.config.URLPARAMS) {
+        params.urlparams = params.urlparams || {};
 		_.extend(params.urlparams, _.isFunction(model.config.URLPARAMS) ? model.config.URLPARAMS() : model.config.URLPARAMS);
 	}
 


### PR DESCRIPTION
We need to make sure that params.urlparams is not undefined before extending it (e.g. no url params are passed as an option but some are defined in the model config). This fix prevents an undefined object from being passed to the Underscore extend method.