### PR TITLE
Update restapi.js

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -84,6 +84,10 @@ function apiCall(_options, _callback) {
 			cleanup();
 		};
 		
+		if (_options.beforeOpen) {
+			_options.beforeOpen(xhr);
+		}
+		
 		//Prepare the request
 		xhr.open(_options.type, _options.url);
 


### PR DESCRIPTION
beforeOpen option that can be used to set xhr properties before open is called. For example, we can use it to set password and username on HTTPClient instance.