### PR TITLE
Allow Headers to be a Function

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -163,8 +163,12 @@ function Sync(method, model, opts) {
 
 	// Send our own custom headers
 	if (model.config.hasOwnProperty("headers")) {
-		for (var header in model.config.headers) {
-			params.headers[header] = model.config.headers[header];
+		var configHeaders = model.config.headers;
+		if (_.isFunction(configHeaders)) {
+			configHeaders = configHeaders();
+		}
+		for (var header in configHeaders) {
+			params.headers[header] = configHeaders[header];
 		}
 	}
 


### PR DESCRIPTION
What if we make things more flexible by allowing a function to be passed for config.headers? This is useful if you're generating a lot of models, and want to allow the headers to change along the way without having to update every model.