### PR TITLE
When encoding, object value should be stringified

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -402,9 +402,10 @@ function traverseProperties(object, string) {
 }
 
 function encodeData(obj, url) {
-	var str = [];
+	var str = [], value;
 	for (var p in obj) {
-		str.push(Ti.Network.encodeURIComponent(p) + "=" + Ti.Network.encodeURIComponent(obj[p]));
+		value = _.isObject(obj[p])?JSON.stringify(obj[p]):obj[p];
+		str.push(Ti.Network.encodeURIComponent(p) + "=" + Ti.Network.encodeURIComponent(value));
 	}
 
 	if (_.indexOf(url, "?") == -1) {


### PR DESCRIPTION
If 

```
col.fetch({
    data : { filter : {what : "value" } }
});
```

url should be `?filter={"what":"value"}`
But adapter make `?filter={<br/> what = value; }`

Look below result

```
Ti.Network.decodeURIComponent(Ti.Network.encodeURIComponent({what:"value"}));
// {<br/> what = value; }
Ti.Network.decodeURIComponent(Ti.Network.encodeURIComponent(JSON.stringify({what:"value"})));
// {"what":"value"}
```

So if data value is object, it should be stringified before encoding.
