### PR TITLE
handle error on backbone 1.1.2

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -227,7 +227,7 @@ function Sync(method, model, opts) {
 					model.trigger("fetch");
 					// fire event
 				} else {
-					params.error(_response.responseJSON, _response.responseText);
+					Alloy.Backbone.VERSION === '0.9.2' ? params.error(_response.responseJSON, _response.responseText) : params.error(_response.responseText);
 					Ti.API.error('[REST API] CREATE ERROR: ');
 					Ti.API.error(_response);
 				}
@@ -284,7 +284,7 @@ function Sync(method, model, opts) {
 					params.success((length === 1) ? values[0] : values, _response.responseText);
 					model.trigger("fetch");
 				} else {
-					params.error(model, _response.responseText);
+					Alloy.Backbone.VERSION === '0.9.2' ? params.error(model, _response.responseText) : params.error(_response.responseText);
 					Ti.API.error('[REST API] READ ERROR: ');
 					Ti.API.error(_response);
 				}
@@ -320,7 +320,7 @@ function Sync(method, model, opts) {
 					params.success(data, JSON.stringify(data));
 					model.trigger("fetch");
 				} else {
-					params.error(model, _response.responseText);
+					Alloy.Backbone.VERSION === '0.9.2' ? params.error(model, _response.responseText) : params.error(_response.responseText);
 					Ti.API.error('[REST API] UPDATE ERROR: ');
 					Ti.API.error(_response);
 				}
@@ -349,7 +349,7 @@ function Sync(method, model, opts) {
 					params.success(null, _response.responseText);
 					model.trigger("fetch");
 				} else {
-					params.error(model, _response.responseText);
+					Alloy.Backbone.VERSION === '0.9.2' ? params.error(model, _response.responseText) : params.error(_response.responseText);
 					Ti.API.error('[REST API] DELETE ERROR: ');
 					Ti.API.error(_response);
 				}


### PR DESCRIPTION
wrapError method of backbone differs between version 0.9.2 and 1.1.2, so this change will make restapi.js works on both versions smoothly.

More details:
wrapError of Backbone 0.9.2 accepts model and response as parameters, but 1.1.2 accepts only response.