### PR TITLE
No responseText causes parse error

### DIFF
--- a/restapi.js
+++ b/restapi.js
@@ -36,7 +36,7 @@ function apiCall(_options, _callback) {
 			if (this.status != 304 && this.status != 204) {
 				// parse JSON
 				try {
-					responseJSON = JSON.parse(this.responseText);
+					if (this.responseText) responseJSON = JSON.parse(this.responseText);
 				} catch (e) {
 					Ti.API.error('[REST API] apiCall PARSE ERROR: ' + e.message);
 					Ti.API.error('[REST API] apiCall PARSE ERROR: ' + this.responseText);


### PR DESCRIPTION
If I get a response with no .responseText (using ArrowDB) but a status e.g. 201 then this fails so adding check for null.